### PR TITLE
Add new features for xray generator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,11 +163,20 @@ jobs:
           path: |
             ./build_assets/*
 
-      - name: Upload binaries to release
+      - name: Upload archives to release
         uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # v2
         if: github.event_name == 'release' || (github.event_name == 'push' && (contains(github.ref, 'refs/tags/')))
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ./wgcf-cli-${{ env.ASSET_NAME }}.tar.zstd*
+          tag: ${{ github.ref }}
+          file_glob: true
+
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # v2
+        if: github.event_name == 'release' || (github.event_name == 'push' && (contains(github.ref, 'refs/tags/')))
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./wgcf-cli-${{ env.ASSET_NAME }}
           tag: ${{ github.ref }}
           file_glob: true

--- a/cmd/wgcf-cli/cmd_generate.go
+++ b/cmd/wgcf-cli/cmd_generate.go
@@ -19,7 +19,7 @@ var generateCmd = &cobra.Command{
 	Short:     "Generate a xray/sing-box/wg-quick config",
 	Run:       generate,
 	Args:      cobra.OnlyValidArgs,
-	ValidArgs: []string{"--xray", "--xray-module", "--xray-tag", "--sing-box", "--wg", "--wg-quick", "--output-file"},
+	ValidArgs: []string{"--xray", "--xray-module", "--xray-tag", "--xray-indent-width", "--sing-box", "--wg", "--wg-quick", "--output-file"},
 }
 
 type OutputFileType int8
@@ -61,6 +61,7 @@ func init() {
 	generateCmd.Flags().String("output-file", "default", "output file name. Supported values: 'default'/'stdout'/any file path")
 	generateCmd.Flags().String(asString(Xray)+"-module", "", "xray top-level config module ('inbounds' as example). By default generate no top-level module")
 	generateCmd.Flags().String(asString(Xray)+"-tag", "wireguard", "'Tag' field of xray config")
+	generateCmd.Flags().Uint8(asString(Xray)+"-indent-width", 4, "indentation size for xray config")
 }
 
 func asString[V fmt.Stringer](object V) string {
@@ -175,10 +176,11 @@ func generate(cmd *cobra.Command, args []string) {
 
 	switch generator {
 	case Xray:
-		conf_module, _ := cmd.Flags().GetString("xray-module")
-		tag, _ := cmd.Flags().GetString("xray-tag")
+		conf_module, _ := cmd.Flags().GetString(asString(Xray) + "-module")
+		tag, _ := cmd.Flags().GetString(asString(Xray) + "-tag")
+		indent_width, _ := cmd.Flags().GetUint8(asString(Xray) + "-indent-width")
 
-		body, err = utils.GenXray(resStruct, tag, conf_module)
+		body, err = utils.GenXray(resStruct, tag, conf_module, indent_width)
 		if err != nil {
 			ExitDefault(err)
 		}
@@ -193,7 +195,7 @@ func generate(cmd *cobra.Command, args []string) {
 
 	switch output_type {
 	case Stdout:
-		_, err = fmt.Print(body)
+		_, err = fmt.Print(string(body))
 		if err != nil {
 			ExitDefault(err)
 		}

--- a/cmd/wgcf-cli/cmd_generate.go
+++ b/cmd/wgcf-cli/cmd_generate.go
@@ -16,7 +16,7 @@ import (
 
 var generateCmd = &cobra.Command{
 	Use:       "generate",
-	Short:     "Generate a xray/sing-box config",
+	Short:     "Generate a xray/sing-box/wg-quick config",
 	Run:       generate,
 	Args:      cobra.OnlyValidArgs,
 	ValidArgs: []string{"--xray", "--sing-box", "--wg", "--wg-quick", "--output-file"},

--- a/cmd/wgcf-cli/cmd_generate.go
+++ b/cmd/wgcf-cli/cmd_generate.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"math/bits"
 	"os"
+	"path"
 	"strings"
 
 	C "github.com/ArchiveNetwork/wgcf-cli/constant"
@@ -16,61 +19,190 @@ var generateCmd = &cobra.Command{
 	Short:     "Generate a xray/sing-box config",
 	Run:       generate,
 	Args:      cobra.OnlyValidArgs,
-	ValidArgs: []string{"--xray", "--sing-box", "--wg"},
+	ValidArgs: []string{"--xray", "--sing-box", "--wg", "--wg-quick", "--output-file"},
+}
+
+type OutputFileType int8
+
+const (
+	Stdout OutputFileType = iota
+	Default
+	Custom
+)
+
+type GeneratorType int8
+
+const (
+	Xray GeneratorType = iota
+	SingBox
+	WgQuick
+	None
+)
+
+func (t GeneratorType) String() string {
+	switch t {
+	case Xray:
+		return "xray"
+	case SingBox:
+		return "sing-box"
+	case WgQuick:
+		return "wg-quick"
+	}
+	return "unknown"
 }
 
 func init() {
 	rootCmd.AddCommand(generateCmd)
-	generateCmd.Flags().Bool("xray", false, "generate a xray config")
-	generateCmd.Flags().Bool("sing-box", false, "generate a sing-box config")
-	generateCmd.Flags().Bool("wg", false, "generate a wg-quick config")
+	generateCmd.Flags().Bool(asString(Xray), false, "generate a xray config")
+	generateCmd.Flags().Bool(asString(SingBox), false, "generate a sing-box config")
+	generateCmd.Flags().Bool(asString(WgQuick), false, "generate a wg-quick config")
+	generateCmd.Flags().Bool("wg", false, "see --"+asString(WgQuick))
+	generateCmd.Flags().String("output-file", "default", "output file name. Supported values: 'default'/'stdout'/any file path")
 }
 
-func generate(cmd *cobra.Command, args []string) {
-	var err error
-	xray, _ := cmd.Flags().GetBool("xray")
-	sing, _ := cmd.Flags().GetBool("sing-box")
-	wg, _ := cmd.Flags().GetBool("wg")
+func asString[V fmt.Stringer](object V) string {
+	return V.String(object)
+}
 
-	var resStruct C.Response
-	body := utils.ReadConfig(configPath)
-	if err := json.Unmarshal(body, &resStruct); err != nil {
-		fmt.Fprintln(os.Stderr, "Error:", err)
-		os.Exit(1)
-	}
-	var gen_type string
-	if xray {
-		body, err = utils.GenXray(resStruct)
-		gen_type = "xray.json"
-	} else if sing {
-		body, err = utils.GenSing(resStruct)
-		gen_type = "sing-box.json"
-	} else if wg {
-		body, err = utils.GenWgQuick(resStruct)
-		gen_type = "ini"
-	}
+func detectOutputFileType(cmd *cobra.Command) (OutputFileType, error) {
+	var err error
+	path, err := cmd.Flags().GetString("output-file")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error:", err)
-		os.Exit(1)
+		return Stdout, err
 	}
-	store := strings.TrimSuffix(configPath, "json") + gen_type
-	if _, err := os.Stat(store); !os.IsNotExist(err) {
+	switch path {
+	case "stdout":
+		return Stdout, nil
+	case "default":
+		return Default, nil
+	}
+	return Custom, nil
+}
+
+func ternary[V any](condition bool, on_true V, on_false V) V {
+	if condition {
+		return on_true
+	}
+	return on_false
+}
+
+func detectGeneratorType(cmd *cobra.Command) (GeneratorType, error) {
+	xray, _ := cmd.Flags().GetBool(asString(Xray))
+	sing, _ := cmd.Flags().GetBool(asString(SingBox))
+	wg, _ := cmd.Flags().GetBool(asString(WgQuick))
+	if !wg {
+		wg, _ = cmd.Flags().GetBool("wg")
+	}
+
+	var options uint8 = 0
+	options |= ternary(xray, uint8(0b001), 0)
+	options |= ternary(sing, uint8(0b010), 0)
+	options |= ternary(wg, uint8(0b100), 0)
+	if c := bits.OnesCount8(options); c != 1 {
+		if c == 0 {
+			return None, errors.New("generator not specified")
+		} else {
+			return None, errors.New("multiple generators not supported")
+		}
+	}
+
+	if xray {
+		return Xray, nil
+	} else if sing {
+		return SingBox, nil
+	} else if wg {
+		return WgQuick, nil
+	}
+	return None, nil
+}
+
+func askOutputOverwrite(path string) {
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		var input string
-		fmt.Fprintf(os.Stderr, "Warn: File %s exist, are you sure to continue? [y/N]: ", store)
+		fmt.Fprintf(os.Stderr, "Warn: File %s exist, it will be overwritten. Continue? [y/N]: ", path)
 		fmt.Scanln(&input)
 		input = strings.ToLower(input)
 		if input != "y" {
 			os.Exit(1)
 		}
 	}
-	if err = os.WriteFile(store, body, 0600); err != nil {
-		fmt.Fprintln(os.Stderr, "Error:", err)
-		os.Exit(1)
+}
+
+func getDefaultFilePath(generator GeneratorType) string {
+	var base_name = strings.TrimSuffix(configPath, path.Ext(configPath))
+	switch generator {
+	case Xray:
+		return base_name + ".xray.json"
+	case SingBox:
+		return base_name + ".sing-box.json"
+	case WgQuick:
+		return base_name + ".ini"
 	}
-	if strings.HasSuffix(gen_type, "ini") {
-		gen_type = "wg-quick"
-	} else {
-		gen_type = strings.TrimSuffix(gen_type, ".json")
+	return ""
+}
+
+func Exit(err error, exit_code int) {
+	fmt.Fprintln(os.Stderr, "Error:", err)
+	os.Exit(exit_code)
+}
+func ExitDefault(err error) {
+	Exit(err, 1)
+}
+
+func generate(cmd *cobra.Command, args []string) {
+	var err error
+	var generator GeneratorType
+	var output_type OutputFileType
+
+	output_type, err = detectOutputFileType(cmd)
+	if err != nil {
+		ExitDefault(err)
 	}
-	fmt.Printf("Generate configuration file (ID: %s) for %s successfully\n", resStruct.ID, gen_type)
+	generator, err = detectGeneratorType(cmd)
+	if err != nil {
+		ExitDefault(err)
+	}
+
+	var resStruct C.Response
+	body := utils.ReadConfig(configPath)
+	err = json.Unmarshal(body, &resStruct)
+	if err != nil {
+		ExitDefault(err)
+	}
+
+	switch generator {
+	case Xray:
+		body, err = utils.GenXray(resStruct)
+	case SingBox:
+		body, err = utils.GenSing(resStruct)
+	case WgQuick:
+		body, err = utils.GenWgQuick(resStruct)
+	}
+	if err != nil {
+		ExitDefault(err)
+	}
+
+	switch output_type {
+	case Stdout:
+		_, err = fmt.Print(body)
+		if err != nil {
+			ExitDefault(err)
+		}
+	case Default:
+		var filepath = getDefaultFilePath(generator)
+		askOutputOverwrite(filepath)
+		err = os.WriteFile(filepath, body, 0600)
+		if err != nil {
+			ExitDefault(err)
+		}
+		fmt.Printf("Generate %s configuration file '%s' (ID: %s) successfully\n", asString(generator), filepath, resStruct.ID)
+	case Custom:
+		filepath, _ := cmd.Flags().GetString("output-file")
+		askOutputOverwrite(filepath)
+		err = os.WriteFile(filepath, body, 0600)
+		if err != nil {
+			ExitDefault(err)
+		}
+		fmt.Printf("Generate %s configuration file '%s' (ID: %s) successfully\n", asString(generator), filepath, resStruct.ID)
+	}
 }

--- a/cmd/wgcf-cli/cmd_generate.go
+++ b/cmd/wgcf-cli/cmd_generate.go
@@ -60,7 +60,7 @@ func init() {
 
 	generateCmd.Flags().String("output-file", "default", "output file name. Supported values: 'default'/'stdout'/any file path")
 	generateCmd.Flags().String(asString(Xray)+"-module", "", "xray top-level config module ('inbounds' as example). By default generate no top-level module")
-	generateCmd.Flags().String(asString(Xray)+"-tag", "wireguard", "'Tag' field of xray config. 'wireguard' by default")
+	generateCmd.Flags().String(asString(Xray)+"-tag", "wireguard", "'Tag' field of xray config")
 }
 
 func asString[V fmt.Stringer](object V) string {

--- a/cmd/wgcf-cli/cmd_generate.go
+++ b/cmd/wgcf-cli/cmd_generate.go
@@ -19,7 +19,7 @@ var generateCmd = &cobra.Command{
 	Short:     "Generate a xray/sing-box/wg-quick config",
 	Run:       generate,
 	Args:      cobra.OnlyValidArgs,
-	ValidArgs: []string{"--xray", "--sing-box", "--wg", "--wg-quick", "--output-file"},
+	ValidArgs: []string{"--xray", "--xray-module", "--xray-tag", "--sing-box", "--wg", "--wg-quick", "--output-file"},
 }
 
 type OutputFileType int8
@@ -57,7 +57,10 @@ func init() {
 	generateCmd.Flags().Bool(asString(SingBox), false, "generate a sing-box config")
 	generateCmd.Flags().Bool(asString(WgQuick), false, "generate a wg-quick config")
 	generateCmd.Flags().Bool("wg", false, "see --"+asString(WgQuick))
+
 	generateCmd.Flags().String("output-file", "default", "output file name. Supported values: 'default'/'stdout'/any file path")
+	generateCmd.Flags().String(asString(Xray)+"-module", "", "xray top-level config module ('inbounds' as example). By default generate no top-level module")
+	generateCmd.Flags().String(asString(Xray)+"-tag", "wireguard", "'Tag' field of xray config. 'wireguard' by default")
 }
 
 func asString[V fmt.Stringer](object V) string {
@@ -172,7 +175,13 @@ func generate(cmd *cobra.Command, args []string) {
 
 	switch generator {
 	case Xray:
-		body, err = utils.GenXray(resStruct)
+		conf_module, _ := cmd.Flags().GetString("xray-module")
+		tag, _ := cmd.Flags().GetString("xray-tag")
+
+		body, err = utils.GenXray(resStruct, tag, conf_module)
+		if err != nil {
+			ExitDefault(err)
+		}
 	case SingBox:
 		body, err = utils.GenSing(resStruct)
 	case WgQuick:

--- a/cmd/wgcf-cli/main_test.go
+++ b/cmd/wgcf-cli/main_test.go
@@ -51,6 +51,9 @@ func TestRootCmd(t *testing.T) {
 	rootCmd.SetArgs([]string{"generate", "--wg"})
 	must(rootCmd.Execute())
 
+	rootCmd.SetArgs([]string{"generate", "--wg-quick"})
+	must(rootCmd.Execute())
+
 	rootCmd.SetArgs([]string{"generate", "--sing-box"})
 	must(rootCmd.Execute())
 

--- a/utils/generate.go
+++ b/utils/generate.go
@@ -3,11 +3,12 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	C "github.com/ArchiveNetwork/wgcf-cli/constant"
 )
 
-func GenXray(resStruct C.Response, tag string, config_module string) (body []byte, err error) {
+func GenXray(resStruct C.Response, tag string, config_module string, indent_size uint8) (body []byte, err error) {
 	config_body_json := C.Xray{
 		Protocol: "wireguard",
 		Settings: struct {
@@ -39,11 +40,13 @@ func GenXray(resStruct C.Response, tag string, config_module string) (body []byt
 		},
 		Tag: tag,
 	}
+	
+	indent := strings.Repeat(" ", int(indent_size))
 	if config_module == "" {
-		body, err = json.MarshalIndent(config_body_json, "", "    ")
+		body, err = json.MarshalIndent(config_body_json, "", indent)
 	} else {
 		var config_json = map[string][]C.Xray{config_module: {config_body_json}}
-		body, err = json.MarshalIndent(config_json, "", "    ")
+		body, err = json.MarshalIndent(config_json, "", indent)
 	}
 	return
 }

--- a/utils/generate.go
+++ b/utils/generate.go
@@ -7,8 +7,8 @@ import (
 	C "github.com/ArchiveNetwork/wgcf-cli/constant"
 )
 
-func GenXray(resStruct C.Response) (body []byte, err error) {
-	in_struct := C.Xray{
+func GenXray(resStruct C.Response, tag string, config_module string) (body []byte, err error) {
+	config_body_json := C.Xray{
 		Protocol: "wireguard",
 		Settings: struct {
 			SecretKey string   `json:"secretKey"`
@@ -37,11 +37,14 @@ func GenXray(resStruct C.Response) (body []byte, err error) {
 			Reserved: resStruct.Config.ReservedDec,
 			MTU:      1280,
 		},
-		Tag: "wireguard",
+		Tag: tag,
 	}
-
-	body, err = json.MarshalIndent(in_struct, "", "    ")
-
+	if config_module == "" {
+		body, err = json.MarshalIndent(config_body_json, "", "    ")
+	} else {
+		var config_json = map[string][]C.Xray{config_module: {config_body_json}}
+		body, err = json.MarshalIndent(config_json, "", "    ")
+	}
 	return
 }
 


### PR DESCRIPTION
1. Add `--xray-tag` option for Xray generator.
2. Add `--xray-indent-width` option for Xray generator.
3. Add `--xray-module` option for Xray generator.
4. Add `--output-file` option for all generators. Generators can output config to standard output or custom file now.

If use `--xray-module`, `--xray-tag` options, wgcf-cli can generate complete configuration file, which can be used with [multi-file configuration](https://xtls.github.io/en/config/features/multiple.html) setup.

Default behavior not changed (as far as I know). I'm sorry if my code looks messy, I didn't have Go programming experience before this PR :).

Also cmd_generate.go refactored. 